### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-array KEYWORD1
+array	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-push_back   KEYWORD2
-pop_back    KEYWORD2
-size        KEYWORD2
-max_size    KEYWORD2
-empty       KEYWORD2
-full        KEYWORD2
-reserve     KEYWORD2
-begin       KEYWORD2
-end         KEYWORD2
-bound       KEYWORD2
+push_back	KEYWORD2
+pop_back	KEYWORD2
+size	KEYWORD2
+max_size	KEYWORD2
+empty	KEYWORD2
+full	KEYWORD2
+reserve	KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+bound	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords